### PR TITLE
update: sweep from left to right, point & vertex ord

### DIFF
--- a/src/algorithm/intersection/segment_2_segment_2.rs
+++ b/src/algorithm/intersection/segment_2_segment_2.rs
@@ -100,8 +100,8 @@ mod tests {
         let s2 = Segment2::new(p1, p2);
         let result = segment_2_segment_2_intersection(&s1, &s2);
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], Point2::new(1.0, 1.0));
-        assert_eq!(result[1], Point2::new(1.0, 2.0));
+        assert_eq!(result[0], Point2::new(1.0, 2.0));
+        assert_eq!(result[1], Point2::new(1.0, 1.0));
 
         let p1 = Point2::new(0.0, 0.0);
         let p2 = Point2::new(10.0, 10.0);

--- a/src/kernel/point_2.rs
+++ b/src/kernel/point_2.rs
@@ -67,14 +67,14 @@ impl<T: NumberType> Ord for Point2<T> {
         if self.equals(other) {
             return std::cmp::Ordering::Equal;
         }
-        if self.y > other.y {
+        if self.x() < other.x() {
             return std::cmp::Ordering::Greater;
-        } else if self.y < other.y {
+        } else if self.x() > other.x() {
             return std::cmp::Ordering::Less;
         } else {
-            if self.x > other.x {
+            if self.y() > other.y() {
                 return std::cmp::Ordering::Less;
-            } else if self.x < other.x {
+            } else if self.y() < other.y() {
                 return std::cmp::Ordering::Greater;
             } else {
                 return std::cmp::Ordering::Equal;

--- a/src/kernel/vertex_2.rs
+++ b/src/kernel/vertex_2.rs
@@ -49,26 +49,37 @@ impl<T: NumberType> Vertex2<T> {
     }
 }
 
+impl<T: NumberType> Eq for Vertex2<T> {}
+
 impl<T: NumberType> PartialEq for Vertex2<T> {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
     }
 }
 
-impl<T: NumberType> PartialOrd for Vertex2<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.y() > other.y() {
-            return Some(std::cmp::Ordering::Greater);
-        } else if self.y() < other.y() {
-            return Some(std::cmp::Ordering::Less);
+impl<T: NumberType> Ord for Vertex2<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.equals(other) {
+            return std::cmp::Ordering::Equal;
+        }
+        if self.x() < other.x() {
+            return std::cmp::Ordering::Greater;
+        } else if self.x() > other.x() {
+            return std::cmp::Ordering::Less;
         } else {
-            if self.x() > other.x() {
-                return Some(std::cmp::Ordering::Less);
-            } else if self.x() < other.x() {
-                return Some(std::cmp::Ordering::Greater);
+            if self.y() > other.y() {
+                return std::cmp::Ordering::Less;
+            } else if self.y() < other.y() {
+                return std::cmp::Ordering::Greater;
             } else {
-                return Some(std::cmp::Ordering::Equal);
+                return std::cmp::Ordering::Equal;
             }
         }
+    }
+}
+
+impl<T: NumberType> PartialOrd for Vertex2<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }


### PR DESCRIPTION
# Update

Old sweep line was from the top to the bottom, but now it is from the left to the right. So the point and vertex `Ord` was changed.

# Fix

Fix the bug of horizontal or vertical line in the sweep line algorithm.